### PR TITLE
feat: Add .ssignore support

### DIFF
--- a/InterviewExample.csproj
+++ b/InterviewExample.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{89F13FB5-2E99-433E-B325-7F5A2F72EAB8}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>InterviewExample</RootNamespace>
+    <RootNamespace>CommBank.Api.Provisioning.Services</RootNamespace>
     <AssemblyName>InterviewExample</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -46,6 +46,8 @@
     <Compile Include="CSharpTemplate.cs" />
     <Compile Include="DirectoryInfoExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SlipstreamIgnoreFileLoader.cs" />
+    <Compile Include="TemplateIgnoreContentProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/SlipstreamIgnoreFileLoader.cs
+++ b/SlipstreamIgnoreFileLoader.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CommBank.Api.Provisioning.Services.Source
+{
+    /// <summary>
+    /// Provides the ability to load .ssignore file content, if one is present in the scaffold.
+    /// </summary>
+    public interface ISlipstreamIgnoreFileLoader
+    {
+        /// <summary>
+        /// Loads .ssignore content as individual rows.
+        /// </summary>
+        /// <param name="path">The path to folder where .ssignore file is located.</param>
+        /// <returns>Non empty entries from the .ssignore file; <see langword="null"/> if the file can't be loaded.</returns>
+        List<string> LoadEntries(string path);
+    }
+
+    /// <summary>
+    /// Loads .ssignore file content, if one is present in the scaffold.
+    /// </summary>
+    public sealed class SlipstreamIgnoreFileLoader : ISlipstreamIgnoreFileLoader
+    {
+        public const string IgnoreFileName = ".ssignore";
+
+
+        /// <summary>
+        /// Loads .ssignore content as individual rows.
+        /// </summary>
+        /// <param name="path">The path to folder where .ssignore file is located.</param>
+        /// <returns>Non empty entries from the .ssignore file; <see langword="null"/> if the file can't be loaded.</returns>
+        public List<string> LoadEntries(string path)
+        {
+            try
+            {
+                var fullPath = Path.Combine(path, IgnoreFileName);
+                if (!File.Exists(fullPath))
+                {
+                    return null;
+                }
+
+                var reader = File.OpenText(fullPath);
+                return reader.ReadToEnd().Split(new[] { "\r\n" }, StringSplitOptions.None).ToList();
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/TemplateIgnoreContentProvider.cs
+++ b/TemplateIgnoreContentProvider.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CommBank.Api.Provisioning.Services.Source
+{
+    /// <summary>
+    /// For a given scaffold folder provides the ability to retrieve items which are to be ignored during the provisioning.
+    /// </summary>
+    public interface ITemplateIgnoreContentProvider
+    {
+        List<string> Get(string scaffoldPath);
+    }
+
+    /// <summary>
+    /// For a given scaffold folder provides items which are to be ignored during the provisioning.
+    /// Template ignores will be read from .ssignore file, if the scaffold contains it.
+    /// Otherwise the default set of ignore entries is provided.
+    /// </summary>
+    public sealed class TemplateIgnoreContentProvider : ITemplateIgnoreContentProvider
+    {
+        private static readonly List<string> DefaultIgnoreDirs = new List<string> { ".git", "node_modules", "bin", "obj" };
+        private readonly ISlipstreamIgnoreFileLoader _slipStreamIgnoreFileLoader;
+
+
+        public TemplateIgnoreContentProvider(ISlipstreamIgnoreFileLoader slipStreamIgnoreFileLoader)
+        {
+            _slipStreamIgnoreFileLoader = slipStreamIgnoreFileLoader;
+        }
+
+
+        public List<string> Get(string scaffoldPath)
+        {
+            if (string.IsNullOrWhiteSpace(scaffoldPath))
+            {
+                throw new ArgumentNullException(nameof(scaffoldPath));
+            }
+
+            var content = _slipStreamIgnoreFileLoader.LoadEntries(scaffoldPath);
+            if (content == null)
+            {
+                // .templateignore file either not found or can't be read.
+                // provide default ignores to retain the existing behavior
+                return DefaultIgnoreDirs;
+            }
+            else
+            {
+                return content.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct().Select(x => x.Trim()).ToList();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allow each scaffold to contain .ssignore file which contains a collection of files and folders
to be excluded from processing during the provisioning.
The concept of .ssignore file is similar to of .gitignore, although only basic wildcards are currently supported.

If a scaffold does not contain own copy of .ssignore file then the default set of ignores is applied to the
scaffold (".git", "node_modules", "bower_components", "packages", "bin", "obj")